### PR TITLE
This is an AWS specific fix to prevent connections from auto refreshing

### DIFF
--- a/fluent.conf
+++ b/fluent.conf
@@ -18,7 +18,7 @@
     logstash_format true
     logstash_prefix "#{ENV["ELASTICSEARCH_PREFIX"]}"
     time_key timestamp
-    reload_connections false
+    reconnect_on_error true
     flush_interval 5
     port 9200
   </store>

--- a/fluent.conf
+++ b/fluent.conf
@@ -18,6 +18,7 @@
     logstash_format true
     logstash_prefix "#{ENV["ELASTICSEARCH_PREFIX"]}"
     time_key timestamp
+    reload_connections false
     flush_interval 5
     port 9200
   </store>


### PR DESCRIPTION
Logs were simply stopping after a practicable interval.  This config setting corrects that.

https://github.com/uken/fluent-plugin-elasticsearch/issues/182